### PR TITLE
`improv` : replace println debug logs with env logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 .DS_Store
 */**/.DS_Store
+
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2522,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,6 +3351,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -6526,6 +6582,7 @@ dependencies = [
  "chrono",
  "crankx",
  "flate2",
+ "log",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -6581,6 +6638,7 @@ dependencies = [
  "crankx",
  "criterion",
  "flate2",
+ "log",
  "num_cpus",
  "num_enum",
  "rand 0.8.5",
@@ -6636,7 +6694,9 @@ dependencies = [
  "console",
  "dialoguer",
  "dirs",
+ "env_logger",
  "indicatif",
+ "log",
  "mime",
  "mime_guess",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ indicatif = "0.17"
 console = "0.15"
 mime = "0.3"
 mime_guess = "2.0"
+log = "0.4"
+env_logger = "0.11"
 
 # network-specific
 futures = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,6 +32,8 @@ reqwest = { workspace = true, features = ["default"] }
 indicatif.workspace = true
 console.workspace = true
 num_enum.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 mime.workspace = true
 mime_guess.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,9 +12,16 @@ use solana_sdk::commitment_config::CommitmentConfig;
 use cli::{Cli, Commands};
 use keypair::{ get_payer, get_keypair_path };
 use commands::{admin, read, write, info, snapshot, network, claim};
+use env_logger::{self, Env};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+
+    // setup env_logger
+    env_logger::Builder::from_env(Env::default()
+        .default_filter_or(format!("tape_network=trace,tape_client=trace"))).init();
+    
+   
     log::print_title(format!("⊙⊙ TAPEDRIVE {}", env!("CARGO_PKG_VERSION")).as_str());
 
     let cli = Cli::parse();

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,6 +29,7 @@ serde_json.workspace = true
 sha3.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
+log.workspace = true
 
 spl-token.workspace = true
 spl-associated-token-account.workspace = true

--- a/client/src/tape/encoding.rs
+++ b/client/src/tape/encoding.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, anyhow};
+use log::debug;
 use crate::utils::*;
 use super::{TapeHeader, TapeFlags, CompressionAlgo};
 use tape_api::prelude::*;
@@ -77,8 +78,6 @@ pub fn unprefix_segments(data: Vec<u8>, data_length: usize) -> Result<Vec<u8>> {
             return Err(anyhow!("Invalid segment size: too small"));
         }
 
-        // println!("DEBUG: chunk {:?}", chunk);
-
         let seg_num_bytes: [u8; 8] = chunk[0..8].try_into().map_err(|_| anyhow!("Failed to read segment number"))?;
         let seg_num = u64::from_be_bytes(seg_num_bytes);
 
@@ -100,7 +99,7 @@ pub fn unprefix_segments(data: Vec<u8>, data_length: usize) -> Result<Vec<u8>> {
         }
         for i in 0..segments.len() - 1 {
             if segments[i + 1].0 != segments[i].0 + 1 {
-                println!("DEBUG: Segment {} is not consecutive with segment {}", segments[i].0, segments[i + 1].0);
+                debug!("Segment {} is not consecutive with segment {}", segments[i].0, segments[i + 1].0);
                 return Err(anyhow!("Non-consecutive segments detected"));
             }
         }

--- a/client/src/tape/write.rs
+++ b/client/src/tape/write.rs
@@ -26,7 +26,6 @@ pub async fn write_to_tape(
     );
 
     let sig = send_with_retry(client, &instruction, signer, MAX_RETRIES).await?;
-    //println!("DEBUG: {}", sig);
     Ok(sig)
 }
 

--- a/client/src/utils/block.rs
+++ b/client/src/utils/block.rs
@@ -125,8 +125,6 @@ fn verify_counts(tape_block: &TapeBlock) -> Result<(), BlockError> {
         }
     }
 
-    // println!("[Counts] Write: {}, Update: {}, Finalize: {}", write_events, update_events, finalize_events);
-
     if tape_block.events.len() != tape_block.instructions.len() {
         return Err(BlockError::CountMismatch(
             "Events and Instructions",

--- a/client/src/utils/rpc.rs
+++ b/client/src/utils/rpc.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use base64;
+use log::debug;
 use solana_client::{
     nonblocking::rpc_client::RpcClient,
     rpc_client::GetConfirmedSignaturesForAddress2Config,
@@ -107,8 +108,8 @@ pub async fn send_with_retry(
                 attempts += 1;
                 let delay_ms = INITIAL_BACKOFF * (1 << attempts);
 
-                println!(
-                    "DEBUG: send_with_retry attempt {}/{}, waiting {}ms: {}",
+                debug!(
+                    "send_with_retry attempt {}/{}, waiting {}ms: {}",
                     attempts, max_retries, delay_ms, e
                 );
 
@@ -139,8 +140,8 @@ pub async fn get_transaction_with_retry(
             Err(e) if attempts < max_retries => {
                 attempts += 1;
                 let delay_ms = INITIAL_BACKOFF * (1 << attempts);
-                println!(
-                    "DEBUG: get_transaction_with_retry attempt {}/{}, waiting {}ms: {}",
+                debug!(
+                    "get_transaction_with_retry attempt {}/{}, waiting {}ms: {}",
                     attempts, max_retries, delay_ms, e
                 );
                 sleep(Duration::from_millis(delay_ms)).await;

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -39,6 +39,8 @@ solana-transaction-status.workspace = true
 solana-account-decoder.workspace = true
 solana-transaction-status-client-types.workspace = true
 thiserror.workspace = true
+log.workspace = true
+
 axum = "0.8.4"
 num_cpus = "1.17.0"
 tar = "0.4.44"

--- a/network/src/archive.rs
+++ b/network/src/archive.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use log::{debug, error};
 use std::collections::HashSet;
 use solana_transaction_status_client_types::TransactionDetails;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -21,9 +22,9 @@ pub async fn archive_loop(
 ) -> Result<()> {
     // If a trusted peer is provided, sync with it first
     if let Some(peer_url) = trusted_peer.clone() {
-        println!("DEBUG: Using trusted peer: {}", peer_url);
-        println!("DEBUG: Syncing with trusted peer");
-        println!("DEBUG: This may take a while... please be patient");
+        debug!("Using trusted peer: {}", peer_url);
+        debug!("Syncing with trusted peer");
+        debug!("This may take a while... please be patient");
         sync_with_trusted_peer(store, client, &peer_url).await?;
     }
 
@@ -36,7 +37,7 @@ pub async fn archive_loop(
         }
     };
 
-    println!("DEBUG: Initial slot tip: {}", latest_slot);
+    debug!("Initial slot tip: {}", latest_slot);
 
     // Resume from store or start at current tip
     let mut last_processed_slot = starting_slot
@@ -53,8 +54,8 @@ pub async fn archive_loop(
             &mut last_processed_slot,
             &mut iteration_count,
         ).await {
-            Ok(()) => println!("DEBUG: Block processing iteration completed successfully"),
-            Err(e) => eprintln!("ERROR: Block processing iteration failed: {:?}", e),
+            Ok(()) => debug!("Block processing iteration completed successfully"),
+            Err(e) => error!("Block processing iteration failed: {:?}", e),
         }
 
         print_drift_status(store, latest_slot, last_processed_slot);
@@ -281,8 +282,8 @@ fn print_drift_status(
         "Falling behind"
     };
 
-    println!(
-        "DEBUG: Drift {} slots behind tip ({}), status: {}",
+    debug!(
+        "Drift {} slots behind tip ({}), status: {}",
         drift, latest_slot, health_status
     );
 }


### PR DESCRIPTION
Replace println! debug logs with env logs 

- Less expensive: avoids formatting and I/O cost when logs are disabled
- Level-based filtering: control output via RUST_LOG, e.g. RUST_LOG=tape_miner=debug
- standard logging interface for consistent output and future observability
- Thread-safe and async-friendly: works correctly in concurrent environments