### PR TITLE
`improv` : optimize mining and archiving using tokio concurrency and cleanup

### DIFF
--- a/cli/src/commands/snapshot.rs
+++ b/cli/src/commands/snapshot.rs
@@ -55,7 +55,7 @@ pub async fn handle_snapshot_commands(cli: Cli, client: Arc<RpcClient>,) -> Resu
 
 fn handle_stats() -> Result<()> {
     let store: TapeStore = get_read_only_store()?;
-    let stats = store.get_local_stats()?;
+    let stats = store.read_local_stats()?;
     log::print_section_header("Local Store Stats");
     log::print_message(&format!("Number of Tapes: {}", stats.tapes));
     log::print_message(&format!("Number of Segments: {}", stats.segments));
@@ -103,7 +103,7 @@ async fn handle_get_tape(
     let mut data: Vec<u8> = Vec::with_capacity((total_segments as usize) * SEGMENT_SIZE);
     let mut missing: Vec<u64> = Vec::new();
     for seg_idx in 0..total_segments {
-        match store.get_segment_by_address(&tape_pubkey, seg_idx) {
+        match store.read_segment_by_address(&tape_pubkey, seg_idx) {
             Ok(seg) => {
                 let canonical_seg = padded_array::<SEGMENT_SIZE>(&seg);
                 data.extend_from_slice(&canonical_seg);
@@ -152,7 +152,7 @@ async fn handle_get_segment(client: &Arc<RpcClient>, tape: &str, index: u32) -> 
 
     let store: TapeStore = get_read_only_store()?;
 
-    match store.get_segment_by_address(&tape_pubkey, index as u64) {
+    match store.read_segment_by_address(&tape_pubkey, index as u64) {
         Ok(data) => {
             let mut stdout = io::stdout();
             stdout.write_all(&data)?;

--- a/client/src/mine/mine.rs
+++ b/client/src/mine/mine.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Result};
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
     signature::{Keypair, Signature, Signer},
-    transaction::Transaction,
     pubkey::Pubkey,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -33,20 +32,14 @@ pub async fn perform_mining(
         merkle_proof,
     );
 
-    let blockhash_bytes = get_latest_blockhash(client).await?;
-    let recent_blockhash = deserialize(&blockhash_bytes)?;
-    let tx = Transaction::new_signed_with_payer(
+    let signature = build_send_and_confirm_tx(
         &[compute_budget_ix, mine_ix],
-        Some(&signer.pubkey()),
-        &[signer],
-        recent_blockhash,
-    );
-
-    let signature_bytes = send_and_confirm_transaction(client, &tx)
-        .await
-        .map_err(|e| anyhow!("Failed to mine: {}", e))?;
-
-    let signature: Signature = deserialize(&signature_bytes)?;
+        client,
+        signer.pubkey(),
+        &[signer]
+    )
+    .await
+    .map_err(|e| anyhow!("Failed to mine: {}", e))?;
 
     Ok(signature)
 }

--- a/client/src/mine/register.rs
+++ b/client/src/mine/register.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Result};
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
     signature::{Keypair, Signature, Signer},
-    transaction::Transaction,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 
@@ -20,20 +19,14 @@ pub async fn register_miner(
     let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(50_000);
     let register_ix = build_register_ix(signer.pubkey(), name);
 
-    let blockhash_bytes = get_latest_blockhash(client).await?;
-    let recent_blockhash = deserialize(&blockhash_bytes)?;
-    let tx = Transaction::new_signed_with_payer(
+    let signature = build_send_and_confirm_tx(
         &[compute_budget_ix, register_ix],
-        Some(&signer.pubkey()),
-        &[signer],
-        recent_blockhash,
-    );
-
-    let signature_bytes = send_and_confirm_transaction(client, &tx)
-        .await
-        .map_err(|e| anyhow!("Failed to register miner: {}", e))?;
-
-    let signature: Signature = deserialize(&signature_bytes)?;
+        client,
+        signer.pubkey(),
+        &[signer]
+    )
+    .await
+    .map_err(|e| anyhow!("Failed to register miner: {}", e))?;
 
     Ok(signature)
 }

--- a/client/src/program/initialize.rs
+++ b/client/src/program/initialize.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Result};
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
     signature::{Keypair, Signature, Signer},
-    transaction::Transaction,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 
@@ -15,21 +14,14 @@ pub async fn initialize(client: &Arc<RpcClient>, signer: &Keypair) -> Result<Sig
     let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(250_000);
     let create_ix = build_initialize_ix(signer.pubkey());
 
-    let blockhash_bytes = get_latest_blockhash(client).await?;
-    let recent_blockhash = deserialize(&blockhash_bytes)?;
-    let tx = Transaction::new_signed_with_payer(
-        &[
-            compute_budget_ix, 
-            create_ix
-        ],
-        Some(&signer.pubkey()),
-        &[signer],
-        recent_blockhash,
-    );
+    let signature = build_send_and_confirm_tx(
+        &[compute_budget_ix,create_ix],
+        client,
+        signer.pubkey(),
+        &[signer]
+    )
+    .await
+    .map_err(|e| anyhow!("Failed to initialize program: {}", e))?;
 
-    let signature_bytes = send_and_confirm_transaction(client, &tx)
-        .await
-        .map_err(|e| anyhow!("Failed to initialize program: {}", e))?;
-    let signature: Signature = deserialize(&signature_bytes)?;
     Ok(signature)
 }

--- a/client/src/tape/create.rs
+++ b/client/src/tape/create.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use solana_sdk::{
     signature::{Keypair, Signer, Signature},
-    transaction::Transaction,
     pubkey::Pubkey,
 };
 use tape_api::prelude::*;
@@ -25,16 +24,12 @@ pub async fn create_tape(
         name, 
     );
 
-    let blockhash_bytes = get_latest_blockhash(client).await?;
-    let recent_blockhash = deserialize(&blockhash_bytes)?;
-    let create_tx = Transaction::new_signed_with_payer(
+    let signature = build_send_and_confirm_tx(
         &[create_ix],
-        Some(&signer.pubkey()),
-        &[signer],
-        recent_blockhash,
-    );
-
-    let signature = send_and_confirm(client, &create_tx).await?;
+        client,
+        signer.pubkey(),
+        &[signer]
+    ).await?;
 
     Ok((tape_address, writer_address, signature))
 }

--- a/client/src/tape/finalize.rs
+++ b/client/src/tape/finalize.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use solana_sdk::{
     signature::{Keypair, Signer},
-    transaction::Transaction,
     pubkey::Pubkey,
 };
 use tape_api::prelude::*;
@@ -24,16 +23,12 @@ pub async fn finalize_tape(
         writer_address,
     );
 
-    let blockhash_bytes = get_latest_blockhash(client).await?;
-    let recent_blockhash = deserialize(&blockhash_bytes)?;
-    let finalize_tx = Transaction::new_signed_with_payer(
+    build_send_and_confirm_tx(
         &[finalize_ix],
-        Some(&signer.pubkey()),
-        &[signer],
-        recent_blockhash,
-    );
-
-    send(client, &finalize_tx).await?;
+        client,
+        signer.pubkey(),
+        &[signer]
+    ).await?;
 
     Ok(())
 }

--- a/client/src/tape/header.rs
+++ b/client/src/tape/header.rs
@@ -6,7 +6,6 @@ use bytemuck::{Pod, Zeroable};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use solana_sdk::{
     signature::{Keypair, Signer, Signature},
-    transaction::Transaction,
     pubkey::Pubkey,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -235,16 +234,12 @@ pub async fn set_header(
         header_data
     );
 
-    let blockhash_bytes = get_latest_blockhash(client).await?;
-    let recent_blockhash = deserialize(&blockhash_bytes)?;
-    let create_tx = Transaction::new_signed_with_payer(
+    let signature = build_send_and_confirm_tx(
         &[set_header_ix],
-        Some(&signer.pubkey()),
-        &[signer],
-        recent_blockhash,
-    );
-
-    let signature = send_and_confirm(client, &create_tx).await?;
+        client,
+        signer.pubkey(),
+        &[signer]
+    ).await?;
 
     Ok((tape_address, signature))
 }

--- a/client/src/utils/ata.rs
+++ b/client/src/utils/ata.rs
@@ -17,7 +17,7 @@ pub async fn create_ata(
 ) -> Result<(Pubkey, Signature)> {
     let token_program_id = &spl_token::ID;
     let mint             = &tape_api::MINT_ADDRESS;
-    let payer_pk         = payer.pubkey();
+    let payer_pk          = payer.pubkey();
     let owner            = &payer_pk;
 
     let ata = spl_associated_token_account::get_associated_token_address_with_program_id(

--- a/client/src/utils/rpc.rs
+++ b/client/src/utils/rpc.rs
@@ -79,6 +79,29 @@ pub async fn send(client: &Arc<RpcClient>, tx: &Transaction) -> Result<Signature
     deserialize(&signature_bytes)
 }
 
+
+// Build Tx from ixs , send and confirm
+pub async fn build_send_and_confirm_tx(
+    ixs: &[Instruction],
+    client: &Arc<RpcClient>,
+    payer: Pubkey,
+    signers : &[&Keypair]
+) -> Result<Signature> {
+
+    let blockhash_bytes = get_latest_blockhash(client).await?;
+    let recent_blockhash = deserialize(&blockhash_bytes)?;
+    let tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&payer),
+        signers,
+        recent_blockhash,
+    );
+
+    let signature_bytes = send_and_confirm_transaction(client, &tx).await?;
+    deserialize(&signature_bytes)
+}
+
+
 /// Sends and confirms a transaction, returning its signature.
 pub async fn send_and_confirm(client: &Arc<RpcClient>, tx: &Transaction) -> Result<Signature> {
     let signature_bytes = send_and_confirm_transaction(client, tx).await?;

--- a/network/src/archive.rs
+++ b/network/src/archive.rs
@@ -76,13 +76,19 @@ pub async fn archive_loop(
         // Check what our miner needs at this moment
         if let Some(miner_address) = miner_address {
 
-            let block = get_block_account(client)
-                .await
-                .map_err(|e| anyhow!("Failed to get block account: {}", e))?.0;
+            let block_with_miner = tokio::join!(
+                get_block_account(client),
+                get_miner_account(client, &miner_address)
+            );
 
-            let miner = get_miner_account(client, &miner_address)
-                .await
-                .map_err(|e| anyhow!("Failed to get miner account: {}", e))?.0;
+            let (block,miner) = {
+                (
+                    block_with_miner.0 
+                        .map_err(|e| anyhow!("Failed to get block account: {}", e))?.0,
+                    block_with_miner.1
+                        .map_err(|e| anyhow!("Failed to get miner account: {}", e))?.0
+                )
+            };
 
             let miner_challenge = compute_challenge(
                 &block.challenge,
@@ -96,12 +102,12 @@ pub async fn archive_loop(
 
             debug!("Miner currently needs tape number: {tape_number:?}");
 
-            if let Ok(tape_address) = store.get_tape_address(tape_number) {
+            if let Ok(tape_address) = store.read_tape_address(tape_number) {
                 let tape = get_tape_account(client, &tape_address)
                     .await
                     .map_err(|e| anyhow!("Failed to get tape account: {}", e))?.0;
 
-                if let Ok(segment_count) = store.get_segment_count(&tape_address) {
+                if let Ok(segment_count) = store.read_segment_count(&tape_address) {
 
                     // Check if we have the correct number of segments locally
                     if segment_count as u64 != tape.total_segments {
@@ -209,12 +215,12 @@ async fn get_processed_block_by_slot(
 #[allow(dead_code)]
 fn archive_block(store: &TapeStore, block: &ProcessedBlock) -> Result<()> {
     for (address, number) in &block.finalized_tapes {
-        store.add_tape(*number, address)?;
+        store.write_tape(*number, address)?;
     }
 
     for (key, data) in &block.segment_writes {
-        store.add_segment(&key.address, key.segment_number, data.clone())?;
-        store.add_slot(&key.address, key.segment_number, block.slot)?;
+        store.write_segment(&key.address, key.segment_number, data.clone())?;
+        store.write_slot(&key.address, key.segment_number, block.slot)?;
     }
 
     Ok(())
@@ -234,7 +240,7 @@ fn archive_blocks(store: &TapeStore, blocks: Vec<ProcessedBlock>) -> Result<()> 
         let (tape_numbers, tape_addresses): (Vec<_>, Vec<_>) =
             finalized_tapes.into_iter().map(|(addr, num)| (num, addr)).unzip();
 
-        store.add_tapes_batch(&tape_numbers, &tape_addresses)?;
+        store.write_tapes_batch(&tape_numbers, &tape_addresses)?;
 
         // 2. Segment and slot insert batches using fold
         let (segment_addresses, segment_numbers, segment_data): (Vec<Pubkey>, Vec<u64>, Vec<Vec<u8>>) =
@@ -249,8 +255,8 @@ fn archive_blocks(store: &TapeStore, blocks: Vec<ProcessedBlock>) -> Result<()> 
 
         let slot_values = vec![block.slot; segment_addresses.len()];
 
-        store.add_segments_batch(&segment_addresses, &segment_numbers, segment_data)?;
-        store.add_slots_batch(&segment_addresses, &segment_numbers, &slot_values)?;
+        store.write_segments_batch(&segment_addresses, &segment_numbers, segment_data)?;
+        store.write_slots_batch(&segment_addresses, &segment_numbers, &slot_values)?;
     }
 
     Ok(())
@@ -296,7 +302,7 @@ pub async fn sync_from_block(
         })
         .unzip();
 
-        store.add_tapes_batch(&tape_number_vec, &address_vec)?;
+        store.write_tapes_batch(&tape_number_vec, &address_vec)?;
 
         let mut parents: HashSet<u64> = HashSet::new();
 
@@ -333,8 +339,8 @@ pub async fn sync_from_block(
 
         let slot_values = vec![slot; segment_addresses.len()];
 
-        store.add_segments_batch(&segment_addresses, &segment_numbers, segment_data)?;
-        store.add_slots_batch(&segment_addresses, &segment_numbers, &slot_values)?;
+        store.write_segments_batch(&segment_addresses, &segment_numbers, segment_data)?;
+        store.write_slots_batch(&segment_addresses, &segment_numbers, &slot_values)?;
 
         for parent in parents {
             stack.push(parent);
@@ -355,12 +361,12 @@ async fn sync_addresses_from_trusted_peer(
     let http = HttpClient::new();
 
     for tape_number in 1..=total {
-        if store.get_tape_address(tape_number).is_ok() {
+        if store.read_tape_address(tape_number).is_ok() {
             continue;
         }
 
         let tape_address = fetch_tape_address(&http, trusted_peer_url, tape_number).await?;
-        store.add_tape(tape_number, &tape_address)?;
+        store.write_tape(tape_number, &tape_address)?;
     }
 
     Ok(())
@@ -376,10 +382,10 @@ async fn sync_segments_from_trusted_peer(
     let segments = fetch_tape_segments(&http, trusted_peer_url, tape_address).await?;
 
     for (seg_num, data) in segments {
-        if store.get_segment_by_address(tape_address, seg_num).is_ok() {
+        if store.read_segment_by_address(tape_address, seg_num).is_ok() {
             continue;
         }
-        store.add_segment(tape_address, seg_num, data)?;
+        store.write_segment(tape_address, seg_num, data)?;
     }
 
     Ok(())
@@ -395,14 +401,14 @@ async fn sync_addresses_from_solana(
 
     for tape_number in 1..=total {
         // Skip if we already have this tape
-        if store.get_tape_address(tape_number).is_ok() {
+        if store.read_tape_address(tape_number).is_ok() {
             continue;
         }
 
         let some_acc = find_tape_account(client, tape_number).await?;
 
         let (pubkey, _) = some_acc.ok_or(anyhow!("Tape account not found for number {}", tape_number))?;
-        store.add_tape(tape_number, &pubkey)?;
+        store.write_tape(tape_number, &pubkey)?;
     }
 
     Ok(())
@@ -427,7 +433,7 @@ async fn sync_segments_from_solana(
     for seg_num in keys {
         debug!("Syncing segment {seg_num} for tape {tape_address}");
         let segment = padded_array::<SEGMENT_SIZE>(&state.segments[&seg_num]);
-        store.add_segment(tape_address, seg_num, segment.to_vec())?;
+        store.write_segment(tape_address, seg_num, segment.to_vec())?;
     }
 
     Ok(())

--- a/network/src/mine.rs
+++ b/network/src/mine.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use log::{debug, error};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{signature::Keypair, pubkey::Pubkey};
@@ -44,6 +44,26 @@ pub async fn mine_loop(
     }
 }
 
+async fn get_mining_accounts(
+    client: &Arc<RpcClient>,
+    miner_address: &Pubkey
+) -> Result<(Epoch, Block, Miner)> {
+     
+    let (epoch_res, block_res, miner_res) = tokio::join!(
+        get_epoch_account(client),
+        get_block_account(client),
+        get_miner_account(client, miner_address),
+    );
+
+    let (epoch, block, miner) = (
+        epoch_res.map_err(|e| anyhow!("Failed to get epoch account: {}", e))?.0,
+        block_res.map_err(|e| anyhow!("Failed to get block account: {}", e))?.0,
+        miner_res.map_err(|e| anyhow!("Failed to get miner account: {}", e))?.0,
+    );
+
+    Ok((epoch, block, miner))
+}
+
 async fn try_mine_iteration(
     store: &TapeStore,
     client: &Arc<RpcClient>,
@@ -52,17 +72,8 @@ async fn try_mine_iteration(
 ) -> Result<()> {
     debug!("Starting mine process...");
 
-    let epoch = get_epoch_account(client)
-        .await
-        .map_err(|e| anyhow!("Failed to get epoch account: {}", e))?.0;
-
-    let block = get_block_account(client)
-        .await
-        .map_err(|e| anyhow!("Failed to get block account: {}", e))?.0;
-
-    let miner = get_miner_account(client, miner_address)
-        .await
-        .map_err(|e| anyhow!("Failed to get miner account: {}", e))?.0;
+    // fetch epoch, block and miner accounts concurrently
+    let (epoch, block, miner) = get_mining_accounts(client, miner_address).await?;
 
     let miner_challenge = compute_challenge(
         &block.challenge,
@@ -76,7 +87,7 @@ async fn try_mine_iteration(
 
     debug!("Recall tape number: {tape_number:?}");
 
-    let tape_address = store.get_tape_address(tape_number);
+    let tape_address = store.read_tape_address(tape_number);
 
     if let Ok(tape_address) = tape_address {
 
@@ -87,15 +98,15 @@ async fn try_mine_iteration(
             .map_err(|e| anyhow!("Failed to get tape account: {}", e))?.0;
         
         let (solution, recall_segment, merkle_proof) = if tape.has_minimum_rent() {
-            // This tape has minimum rent, we can recall a segment
             
+            // This tape has minimum rent, we can recall a segment
             let segment_number = compute_recall_segment(
                 &miner_challenge,
                 tape.total_segments
             );
 
             // Get the entire tape
-            let segments = store.get_tape_segments(&tape_address)?;
+            let segments = store.read_tape_segments(&tape_address)?;
             if segments.len() != tape.total_segments as usize {
                 return Err(anyhow!("Local store is missing some segments for tape number {}: expected {}, got {}", 
                     tape_address, tape.total_segments, segments.len()));
@@ -113,6 +124,7 @@ async fn try_mine_iteration(
 
         // This tape does not have minimum rent, we use an empty segment
         } else {
+
             debug!("Tape {tape_address} does not have minimum rent, using empty segment");
 
             let solution = solve_challenge(
@@ -133,6 +145,7 @@ async fn try_mine_iteration(
             recall_segment, 
             merkle_proof,
         ).await?;
+
         debug!("Mining successful! Signature: {sig:?}");
 
         let (miner, _) = get_miner_account(client, miner_address)
@@ -146,6 +159,7 @@ async fn try_mine_iteration(
     }
 
     debug!("Catching up with primary...");
+
     store.catch_up_with_primary()?;
 
     Ok(())
@@ -170,7 +184,6 @@ fn compute_challenge_solution(
 
         // Create our canonical segment of exactly SEGMENT_SIZE bytes 
         // and compute the merkle leaf
-
         let data = padded_array::<SEGMENT_SIZE>(segment_data);
         let leaf = compute_leaf(
             *segment_id,
@@ -192,7 +205,7 @@ fn compute_challenge_solution(
         .map(|v| v.to_bytes())
         .collect::<Vec<_>>()
         .try_into()
-        .unwrap();
+        .map_err(|_|anyhow!("failed to get merkle proof"))?;
 
     if merkle_tree.get_root() != tape.merkle_root.into() {
         return Err(anyhow!("Merkle root mismatch"));

--- a/network/src/snapshot.rs
+++ b/network/src/snapshot.rs
@@ -15,7 +15,7 @@ pub fn create_snapshot(db: &DB, archive_path: impl AsRef<Path>) -> Result<(), St
     let checkpoint = Checkpoint::new(db)?;
     let temp_dir = TempDir::new("tapestore")?;
     let checkpoint_dir = temp_dir.path().join("checkpoint");
-    checkpoint.create_checkpoint(checkpoint_dir.to_str().unwrap())?;
+    checkpoint.create_checkpoint(checkpoint_dir.to_str().ok_or(StoreError::InvalidPath)?)?;
 
     let file = File::create(archive_path)?;
     let enc = GzEncoder::new(file, Compression::default());

--- a/network/src/web.rs
+++ b/network/src/web.rs
@@ -170,7 +170,7 @@ pub fn rpc_get_tape_address(store: &TapeStore, params: &Value) -> Result<Value, 
         })?;
 
     store
-        .get_tape_address(tn)
+        .read_tape_address(tn)
         .map(|pk| json!(pk.to_string()))
         .map_err(|e| match e {
             StoreError::TapeNotFound(n) => RpcError {
@@ -212,7 +212,7 @@ pub fn rpc_get_tape_number(store: &TapeStore, params: &Value) -> Result<Value, R
     })?;
 
     store
-        .get_tape_number(&pk)
+        .read_tape_number(&pk)
         .map(|num| json!(num))
         .map_err(|e| match e {
             StoreError::TapeNotFoundForAddress(_) => RpcError {
@@ -258,7 +258,7 @@ pub fn rpc_get_segment(store: &TapeStore, params: &Value) -> Result<Value, RpcEr
         })?;
 
     store
-        .get_segment(tn, sn)
+        .read_segment(tn, sn)
         .map(|data| json!(base64::encode(data)))
         .map_err(|e| match e {
             StoreError::TapeNotFound(_) => RpcError {
@@ -304,7 +304,7 @@ pub fn rpc_get_tape(store: &TapeStore, params: &Value) -> Result<Value, RpcError
         message: format!("invalid pubkey: {e}"),
     })?;
 
-    let segments = store.get_tape_segments(&pk).map_err(|e| match e {
+    let segments = store.read_tape_segments(&pk).map_err(|e| match e {
         StoreError::TapeNotFoundForAddress(_) => RpcError {
             code: ErrorCode::ServerError.code(),
             message: "tape not found".into(),
@@ -360,7 +360,7 @@ pub fn rpc_get_slot(store: &TapeStore, params: &Value) -> Result<Value, RpcError
         })?;
 
     store
-        .get_slot(tn, sn)
+        .read_slot(tn, sn)
         .map(|slot| json!(slot))
         .map_err(|e| match e {
             StoreError::TapeNotFound(_) => RpcError {
@@ -415,7 +415,7 @@ pub fn rpc_get_segment_by_address(store: &TapeStore, params: &Value) -> Result<V
     })?;
 
     store
-        .get_segment_by_address(&pk, sn)
+        .read_segment_by_address(&pk, sn)
         .map(|data| json!(base64::encode(data)))
         .map_err(|e| match e {
             StoreError::SegmentNotFoundForAddress(_, num) => RpcError {
@@ -466,7 +466,7 @@ pub fn rpc_get_slot_by_address(store: &TapeStore, params: &Value) -> Result<Valu
     })?;
 
     store
-        .get_slot_by_address(&pk, sn)
+        .read_slot_by_address(&pk, sn)
         .map(|slot| json!(slot))
         .map_err(|e| match e {
             StoreError::SegmentNotFoundForAddress(_, num) => RpcError {


### PR DESCRIPTION
1. Use concrrency to fetch miner , block and epoch accounts
2. cleanup fn names and simplify sending tx from ixs to solana