### PR TITLE
`imporv` : add concurrency to sync process and separate secondary rocksdb conn for mine and web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,13 @@
 /test-ledger
 /db_tapestore
 /db_tapestore_read
+/db_tapestore_read_mine
+/db_tapestore_read_web
 
 */**/db_tapestore
 */**/db_tapestore_read
+*/**/db_tapestore_read_mine
+*/**/db_tapestore_read_web
 /*.json
 
 .DS_Store

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -263,8 +263,12 @@ impl Context{
         Ok(tape_network::store::primary()?)
     }
 
-    pub fn open_secondary_store_conn(&self) -> Result<TapeStore> {
-        Ok(tape_network::store::secondary()?)
+    pub fn open_secondary_store_conn_mine(&self) -> Result<TapeStore> {
+        Ok(tape_network::store::secondary_mine()?)
+    }
+
+    pub fn open_secondary_store_conn_web(&self) -> Result<TapeStore> {
+        Ok(tape_network::store::secondary_web()?)
     }
 
     pub fn open_read_only_store_conn(&self) -> Result<TapeStore> {

--- a/cli/src/commands/network.rs
+++ b/cli/src/commands/network.rs
@@ -44,7 +44,7 @@ pub async fn handle_web(context: Context, port: Option<u16>) -> Result<()> {
 
     log::print_info("Starting web RPC service...");
     log::print_message(format!("Listening on port {port}").as_str());
-    let store = context.open_secondary_store_conn()?;
+    let store = context.open_secondary_store_conn_web()?;
     web_loop(store, port).await?;
     Ok(())
 }
@@ -63,7 +63,7 @@ pub async fn handle_archive(context: Context, starting_slot: Option<u64>, truste
     let store = context.open_primary_store_conn()?;
 
     log::print_info("Starting archive service...");
-    archive_loop(&store, context.rpc(), miner_address, starting_slot, trusted_peer).await?;
+    archive_loop(store, context.rpc(), miner_address, starting_slot, trusted_peer).await?;
 
     Ok(())
 }
@@ -75,8 +75,8 @@ pub async fn handle_mine(context: Context, pubkey: Option<String>, name: Option<
 
     log::print_message(&format!("Using miner address: {miner_address}"));
 
-    let store = context.open_secondary_store_conn()?;
-    mine_loop(&store, context.rpc(), &miner_address, context.payer()).await?;
+    let store = context.open_secondary_store_conn_mine()?;
+    mine_loop(store, context.rpc(), &miner_address, context.payer()).await?;
     Ok(())
 }
 

--- a/network/src/web.rs
+++ b/network/src/web.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Value};
 use solana_sdk::pubkey::Pubkey;
 
 use crate::metrics::{record_metrics, run_metrics_server};
+use crate::store::run_refresh_store;
 
 use super::store::{StoreError, TapeStore};
 
@@ -510,16 +511,7 @@ async fn rpc_handler(
 }
 
 
-pub fn run_refresh_store(store:&Arc<TapeStore>) {
-    let store = Arc::clone(store);
-    tokio::spawn(async move {
-        let interval = std::time::Duration::from_secs(15);
-        loop {
-            store.catch_up_with_primary().unwrap();
-            tokio::time::sleep(interval).await;
-        }
-    });
-}
+
 
 pub async fn web_loop(
     store: TapeStore,
@@ -531,7 +523,6 @@ pub async fn web_loop(
 
     let store = Arc::new(store);
 
-    // Refresh the store every 15 seconds
     run_refresh_store(&store);
 
     let app = Router::new()


### PR DESCRIPTION
1. Add concurrency to sync process
2. separate rocksdb secondary conn for mine and web process for scaling