### PR TITLE
Add `tape.toml` for configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 */**/.DS_Store
 
 .vscode
+
+*/tape.*.toml
+tape.*.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,11 +1399,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -3399,7 +3419,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -4235,6 +4255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4325,6 +4354,15 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs 4.0.0",
+]
 
 [[package]]
 name = "shlex"
@@ -6753,7 +6791,7 @@ dependencies = [
  "colored",
  "console",
  "dialoguer",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "indicatif",
  "log",
@@ -6763,13 +6801,16 @@ dependencies = [
  "num_enum",
  "packx",
  "reqwest 0.12.15",
+ "serde",
  "serde_json",
+ "shellexpand",
  "solana-client",
  "solana-sdk",
  "tape-api",
  "tape-client",
  "tape-network",
  "tokio",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -7029,10 +7070,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -7041,9 +7106,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.8",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -7794,9 +7874,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ mime = "0.3"
 mime_guess = "2.0"
 log = "0.4"
 env_logger = "0.11"
+shellexpand = "2.1.0"
 
 # network-specific
 futures = "0.3"
@@ -82,6 +83,7 @@ hyper = { version = "1.6.0", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 lazy_static = "1.5.0"
 http-body-util = "0.1.3"
+toml = "0.9.5"
 
 [patch.crates-io]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ packx.workspace = true
 
 anyhow.workspace = true
 chrono.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 clap.workspace = true
 colored.workspace = true
@@ -36,6 +37,8 @@ num_enum.workspace = true
 log.workspace = true
 env_logger.workspace = true
 num_cpus.workspace = true
+toml.workspace = true
+shellexpand.workspace = true
 
 mime.workspace = true
 mime_guess.workspace = true

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -289,7 +289,9 @@ impl Context{
     }
 
     pub fn open_read_only_store_conn(&self) -> Result<TapeStore> {
-        Ok(tape_network::store::read_only()?)
+        let rocksdb_config = self.config.storage.rocksdb.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("RocksDB config not found"))?;
+        Ok(tape_network::store::read_only(&rocksdb_config.primary_path)?)
     }
 
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -92,9 +92,6 @@ pub enum Commands {
     Mine {
         #[arg(help = "Miner account public key", conflicts_with = "name")]
         pubkey: Option<String>,
-
-        #[arg(help = "Name of the miner you're mining with", conflicts_with = "pubkey", short = 'n', long = "name")]
-        name: Option<String>,
     },
     Web {
         #[arg(help = "Port to run the web RPC service on")]
@@ -184,9 +181,6 @@ pub enum InfoCommands {
     Miner {
         #[arg(help = "Miner account public key", conflicts_with = "name")]
         pubkey: Option<String>,
-
-        #[arg(help = "Name of the miner you're mining with", conflicts_with = "pubkey", short = 'n', long = "name")]
-        name: Option<String>,
     },
 
     Archive {},
@@ -303,4 +297,7 @@ impl Context{
         self.config.solana.max_transaction_retries
     }
 
+    pub fn miner_name_owned(&self) -> String {
+        self.config.mining.miner_name.clone()
+    }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -275,7 +275,9 @@ impl Context{
     }
 
     pub fn open_secondary_store_conn_mine(&self) -> Result<TapeStore> {
-        Ok(tape_network::store::secondary_mine()?)
+        let rocksdb_config = self.config.storage.rocksdb.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("RocksDB config not found"))?;
+        Ok(tape_network::store::secondary_mine(&rocksdb_config.primary_path, &rocksdb_config.secondary_path_mine)?)
     }
 
     pub fn open_secondary_store_conn_web(&self) -> Result<TapeStore> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -4,7 +4,6 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::signature::Keypair;
 use tape_network::store::TapeStore;
 use std::env;
-use std::str::FromStr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -188,43 +187,6 @@ pub enum InfoCommands {
     Block {},
 }
 
-#[derive(Debug, Clone)]
-pub enum Cluster {
-    Localnet,
-    Mainnet,
-    Devnet,
-    Testnet,
-    Custom(String),
-}
-
-impl Cluster {
-    pub fn rpc_url(&self) -> String {
-        match self {
-            Cluster::Localnet => "http://127.0.0.1:8899".to_string(),
-            Cluster::Mainnet => "https://api.mainnet-beta.solana.com".to_string(),
-            Cluster::Devnet => "https://api.devnet.solana.com".to_string(),
-            Cluster::Testnet => "https://api.testnet.solana.com".to_string(),
-            Cluster::Custom(url) => url.clone(),
-        }
-    }
-}
-
-impl FromStr for Cluster {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "l" => Ok(Cluster::Localnet),
-            "m" => Ok(Cluster::Mainnet),
-            "d" => Ok(Cluster::Devnet),
-            "t" => Ok(Cluster::Testnet),
-            s if s.starts_with("http://") || s.starts_with("https://") => Ok(Cluster::Custom(s.to_string())),
-            _ => Err(format!(
-                "Invalid cluster value: '{s}'. Use l, m, d, t, or a valid RPC URL (http:// or https://)"
-            )),
-        }
-    }
-}
 
 pub struct Context {
     pub config: Arc<TapeConfig>,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -298,5 +298,9 @@ impl Context{
     pub fn payer(&self) -> &Keypair{
         &self.payer
     }
+    
+    pub fn max_transaction_retries(&self) -> u32 {
+        self.config.solana.max_transaction_retries
+    }
 
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -9,8 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::keypair::{get_keypair_path, get_payer};
-use crate::config::{TapeConfig, TapeConfigError};
-use crate::log;
+use crate::config::TapeConfig;
 
 #[derive(Parser)]
 #[command(
@@ -243,64 +242,7 @@ impl Context{
     pub fn try_build(cli:&Cli) -> Result<Self> {
         
         // loading up configs
-        let config = match TapeConfig::load(&cli.config) {
-            Ok(config) => config,
-            Err(e) => match e {
-                TapeConfigError::ConfigFileNotFound => {
-                    log::print_info("tape.toml not found, creating default configuration...");
-                    match TapeConfig::create_default() {
-                        Ok(config) => {
-                            log::print_info("✓ Default configuration created successfully");
-                            config
-                        },
-                        Err(creation_error) => {
-                            log::print_error(&format!("{}", creation_error));
-                            std::process::exit(1);
-                        }
-                    }
-                },
-
-                TapeConfigError::CustomConfigFileNotFound(path) => {
-                // This happens when user explicitly provided a path that doesn't exist
-                log::print_error(&format!("Custom config file not found: {}", path));
-                log::print_info("Please check the path and try again.");
-                std::process::exit(1);
-            },
-                
-                TapeConfigError::InvalidUrl(msg) => {
-                    log::print_error(&format!("URL Configuration Error: {}", msg));
-                    log::print_info("Please fix the URL in your tape.toml file and try again.");
-                    std::process::exit(1);
-                },
-                
-                TapeConfigError::KeypairNotFound(path) => {
-                    log::print_error(&format!("Keypair not found at path: {}", path));
-                    log::print_info("Please ensure the keypair file exists at the specified path in tape.toml");
-                    std::process::exit(1);
-                },
-                
-                TapeConfigError::FileReadError(io_err) => {
-                    log::print_error(&format!("Could not read config file: {}", io_err));
-                    std::process::exit(1);
-                },
-                
-                TapeConfigError::ParseError(parse_err) => {
-                    log::print_error(&format!("Invalid tape.toml format: {}", parse_err));
-                    log::print_info("Please check your tape.toml file syntax.");
-                    std::process::exit(1);
-                },
-                
-                TapeConfigError::HomeDirectoryNotFound => {
-                    log::print_error("Could not determine home directory");
-                    std::process::exit(1);
-                },
-                
-                TapeConfigError::DefaultConfigCreationFailed(msg) => {
-                    log::print_error(&format!("Failed to create default config: {}", msg));
-                    std::process::exit(1);
-                },
-            }
-        };
+        let config = TapeConfig::load(&cli.config)?;
 
         let rpc_url = config.solana.rpc_url.to_string();
         let commitment_level = config.solana.commitment.to_commitment_config();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -23,7 +23,7 @@ pub struct Cli {
     pub command: Commands,
 
     #[arg(short = 'c', long = "config", help = "Path to config file (overrides default)", global = true)]
-    pub config_path: Option<PathBuf>,
+    pub config: Option<PathBuf>,
 
     #[arg(short = 'k', long = "keypair", global = true)]
     pub keypair_path: Option<PathBuf>,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -281,7 +281,9 @@ impl Context{
     }
 
     pub fn open_secondary_store_conn_web(&self) -> Result<TapeStore> {
-        Ok(tape_network::store::secondary_web()?)
+        let rocksdb_config = self.config.storage.rocksdb.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("RocksDB config not found"))?;
+        Ok(tape_network::store::secondary_web(&rocksdb_config.primary_path, &rocksdb_config.secondary_path_web)?)
     }
 
     pub fn open_read_only_store_conn(&self) -> Result<TapeStore> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -250,7 +250,7 @@ impl Context{
             RpcClient::new_with_commitment(rpc_url.clone(),
             commitment_level)
         );
-        let keypair_path = get_keypair_path(&config.identity.keypair_path);
+        let keypair_path = get_keypair_path(&config.solana.keypair_path);
         let payer = get_payer(keypair_path.clone())?;
         
         Ok(Self {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -271,7 +271,9 @@ impl Context{
     }
 
     pub fn open_primary_store_conn(&self) -> Result<TapeStore> {
-        Ok(tape_network::store::primary()?)
+        let rocksdb_config = self.config.storage.rocksdb.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("RocksDB config not found"))?;
+        Ok(tape_network::store::primary(&rocksdb_config.primary_path)?)
     }
 
     pub fn open_secondary_store_conn_mine(&self) -> Result<TapeStore> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -250,7 +250,7 @@ impl Context{
             RpcClient::new_with_commitment(rpc_url.clone(),
             commitment_level)
         );
-        let keypair_path = get_keypair_path(Some(PathBuf::from(&*shellexpand::tilde(&config.identity.keypair_path))));
+        let keypair_path = get_keypair_path(&config.identity.keypair_path);
         let payer = get_payer(keypair_path.clone())?;
         
         Ok(Self {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -9,7 +9,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::keypair::{get_keypair_path, get_payer};
-use crate::config::TapeConfig;
+use crate::config::{TapeConfig, TapeConfigError};
+use crate::log;
 
 #[derive(Parser)]
 #[command(
@@ -239,7 +240,68 @@ pub struct Context {
 }
 
 impl Context{
-    pub fn try_build(_cli:&Cli, config: &TapeConfig) -> Result<Self> {
+    pub fn try_build(cli:&Cli) -> Result<Self> {
+        
+        // loading up configs
+        let config = match TapeConfig::load(&cli.config) {
+            Ok(config) => config,
+            Err(e) => match e {
+                TapeConfigError::ConfigFileNotFound => {
+                    log::print_info("tape.toml not found, creating default configuration...");
+                    match TapeConfig::create_default() {
+                        Ok(config) => {
+                            log::print_info("✓ Default configuration created successfully");
+                            config
+                        },
+                        Err(creation_error) => {
+                            log::print_error(&format!("{}", creation_error));
+                            std::process::exit(1);
+                        }
+                    }
+                },
+
+                TapeConfigError::CustomConfigFileNotFound(path) => {
+                // This happens when user explicitly provided a path that doesn't exist
+                log::print_error(&format!("Custom config file not found: {}", path));
+                log::print_info("Please check the path and try again.");
+                std::process::exit(1);
+            },
+                
+                TapeConfigError::InvalidUrl(msg) => {
+                    log::print_error(&format!("URL Configuration Error: {}", msg));
+                    log::print_info("Please fix the URL in your tape.toml file and try again.");
+                    std::process::exit(1);
+                },
+                
+                TapeConfigError::KeypairNotFound(path) => {
+                    log::print_error(&format!("Keypair not found at path: {}", path));
+                    log::print_info("Please ensure the keypair file exists at the specified path in tape.toml");
+                    std::process::exit(1);
+                },
+                
+                TapeConfigError::FileReadError(io_err) => {
+                    log::print_error(&format!("Could not read config file: {}", io_err));
+                    std::process::exit(1);
+                },
+                
+                TapeConfigError::ParseError(parse_err) => {
+                    log::print_error(&format!("Invalid tape.toml format: {}", parse_err));
+                    log::print_info("Please check your tape.toml file syntax.");
+                    std::process::exit(1);
+                },
+                
+                TapeConfigError::HomeDirectoryNotFound => {
+                    log::print_error("Could not determine home directory");
+                    std::process::exit(1);
+                },
+                
+                TapeConfigError::DefaultConfigCreationFailed(msg) => {
+                    log::print_error(&format!("Failed to create default config: {}", msg));
+                    std::process::exit(1);
+                },
+            }
+        };
+
         let rpc_url = config.solana.rpc_url.to_string();
         let commitment_level = config.solana.commitment.to_commitment_config();
         let rpc = Arc::new(

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -80,8 +80,8 @@ pub async fn handle_info_commands(cli: Cli, context: Context) -> Result<()> {
                 log::print_divider();
             }
 
-            InfoCommands::Miner { pubkey, name } => {
-                let miner_address = get_or_create_miner(context.rpc(), context.payer(), pubkey, name, false).await?;
+            InfoCommands::Miner { pubkey } => {
+                let miner_address = get_or_create_miner(context.rpc(), context.payer(), pubkey,context.miner_name_owned(), false).await?;
                 let (miner, _) = tapedrive::get_miner_account(context.rpc(), &miner_address).await?;
                 log::print_section_header("Miner Account");
                 log::print_message(&format!("Name: {}", from_name(&miner.name)));

--- a/cli/src/commands/snapshot.rs
+++ b/cli/src/commands/snapshot.rs
@@ -73,7 +73,7 @@ async fn handle_resync(
         context.rpc(), 
         context.payer(), 
         miner_address, 
-        None, 
+        context.miner_name_owned(), 
         false
     ).await?;
     log::print_message(&format!("Using miner address: {miner_pubkey}"));
@@ -125,7 +125,7 @@ async fn handle_get_tape(
         context.rpc(), 
         context.payer(), 
         miner_address, 
-        None, 
+        context.miner_name_owned(), 
         false
     ).await?;
     let miner_bytes = miner_pubkey.to_bytes();
@@ -193,7 +193,7 @@ async fn handle_get_segment(
         context.rpc(), 
         context.payer(), 
         miner_address, 
-        None, 
+        context.miner_name_owned(), 
         false
     ).await?;
     let miner_bytes = miner_pubkey.to_bytes();

--- a/cli/src/commands/write.rs
+++ b/cli/src/commands/write.rs
@@ -77,6 +77,7 @@ pub async fn handle_write_command(cli: Cli, context: Context) -> Result<()> {
         }
 
 
+        let max_transaction_retries = context.max_transaction_retries();
         let Context{
             rpc,
             payer,
@@ -101,7 +102,7 @@ pub async fn handle_write_command(cli: Cli, context: Context) -> Result<()> {
         let (tape_address, writer_address, _sig) =
             create_tape(&rpc, &payer, &tape_name).await?;
 
-        write_chunks(&rpc, &payer, tape_address, writer_address, chunks, &pb).await?;
+        write_chunks(&rpc, &payer, tape_address, writer_address, chunks, &pb, max_transaction_retries).await?;
 
         pb.set_message("finalizing tape...");
         tokio::time::sleep(Duration::from_secs(32)).await;
@@ -173,6 +174,7 @@ async fn write_chunks(
     writer_address: Pubkey,
     chunks: Vec<Vec<u8>>,
     pb: &ProgressBar,
+    max_transaction_retries: u32
 ) -> Result<()> {
     pb.set_message("");
     pb.set_style(
@@ -197,6 +199,7 @@ async fn write_chunks(
                 tape_address,
                 writer_address,
                 &chunk,
+                max_transaction_retries
             )
             .await?;
             pb_clone.inc(1);
@@ -291,4 +294,3 @@ fn read_from_stdin() -> std::io::Result<Vec<u8>> {
     std::io::stdin().read_to_end(&mut buffer)?;
     Ok(buffer)
 }
-

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -23,22 +23,6 @@ pub struct MiningConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PerformanceConfig {
-    pub num_cores: usize,
-    pub max_memory_mb: u64,
-    pub max_poa_threads: u64,
-    pub max_pow_threads: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PerformanceConfig {
-    pub num_cores: usize,
-    pub max_memory_mb: u64,
-    pub max_poa_threads: u64,
-    pub max_pow_threads: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IdentityConfig {
     pub keypair_path: String,
 }
@@ -117,133 +101,6 @@ impl CommitmentLevel {
 }
 
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct StorageConfig {
-    pub backend: StorageBackend,
-    pub rocksdb: Option<RocksDbConfig>, 
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RocksDbConfig {
-    pub primary_path: String,
-    pub secondary_path: Option<String>,
-    pub cache_size_mb: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub enum StorageBackend {
-    RocksDb,
-    Postgres
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LoggingConfig {
-    pub log_level: LogLevel,
-    pub log_path: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    Error,
-    Warn,
-    Info,
-    Debug,
-    Trace,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum CommitmentLevel {
-    Processed,
-    Confirmed, 
-    Finalized,
-}
-
-impl ToString for CommitmentLevel {
-    fn to_string(&self) -> String {
-        match self {
-            CommitmentLevel::Processed => "processed".to_string(),
-            CommitmentLevel::Confirmed => "confirmed".to_string(),
-            CommitmentLevel::Finalized => "finalized".to_string(),
-        }
-    }
-}
-
-impl CommitmentLevel {
-    pub fn to_commitment_config(&self) -> CommitmentConfig {
-        match self {
-            CommitmentLevel::Processed => CommitmentConfig::processed(),
-            CommitmentLevel::Confirmed => CommitmentConfig::confirmed(),
-            CommitmentLevel::Finalized => CommitmentConfig::finalized(),
-        }
-    }
-}
-
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct StorageConfig {
-    pub backend: StorageBackend,
-    pub rocksdb: Option<RocksDbConfig>, 
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RocksDbConfig {
-    pub primary_path: String,
-    pub secondary_path: Option<String>,
-    pub cache_size_mb: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub enum StorageBackend {
-    RocksDb,
-    Postgres
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LoggingConfig {
-    pub log_level: LogLevel,
-    pub log_path: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    Error,
-    Warn,
-    Info,
-    Debug,
-    Trace,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum CommitmentLevel {
-    Processed,
-    Confirmed, 
-    Finalized,
-}
-
-impl ToString for CommitmentLevel {
-    fn to_string(&self) -> String {
-        match self {
-            CommitmentLevel::Processed => "processed".to_string(),
-            CommitmentLevel::Confirmed => "confirmed".to_string(),
-            CommitmentLevel::Finalized => "finalized".to_string(),
-        }
-    }
-}
-
-impl CommitmentLevel {
-    pub fn to_commitment_config(&self) -> CommitmentConfig {
-        match self {
-            CommitmentLevel::Processed => CommitmentConfig::processed(),
-            CommitmentLevel::Confirmed => CommitmentConfig::confirmed(),
-            CommitmentLevel::Finalized => CommitmentConfig::finalized(),
-        }
-    }
-}
-
 impl TapeConfig {
 
    pub fn load_with_path(config_path: &Option<PathBuf>) -> Result<Self, TapeConfigError> {
@@ -319,54 +176,6 @@ impl TapeConfig {
         Ok(())
     }
 
-    fn validate_url(&self, url: &str, field_name: &str, valid_schemes: &[&str]) -> Result<(), TapeConfigError> {
-        let has_valid_scheme = valid_schemes.iter().any(|scheme| url.starts_with(scheme));
-        
-        if !has_valid_scheme {
-            return Err(TapeConfigError::InvalidUrl(
-                format!("{} must start with one of {:?}, found: '{}'", field_name, valid_schemes, url)
-            ));
-        }
-
-        if url.contains(' ') {
-            return Err(TapeConfigError::InvalidUrl(
-                format!("{} cannot contain spaces, found: '{}'", field_name, url)
-            ));
-        }
-
-        if url.trim().is_empty() {
-            return Err(TapeConfigError::InvalidUrl(
-                format!("{} cannot be empty", field_name)
-            ));
-        }
-
-        Ok(())
-    }
-
-    fn validate_url(&self, url: &str, field_name: &str, valid_schemes: &[&str]) -> Result<(), TapeConfigError> {
-        let has_valid_scheme = valid_schemes.iter().any(|scheme| url.starts_with(scheme));
-        
-        if !has_valid_scheme {
-            return Err(TapeConfigError::InvalidUrl(
-                format!("{} must start with one of {:?}, found: '{}'", field_name, valid_schemes, url)
-            ));
-        }
-
-        if url.contains(' ') {
-            return Err(TapeConfigError::InvalidUrl(
-                format!("{} cannot contain spaces, found: '{}'", field_name, url)
-            ));
-        }
-
-        if url.trim().is_empty() {
-            return Err(TapeConfigError::InvalidUrl(
-                format!("{} cannot be empty", field_name)
-            ));
-        }
-
-        Ok(())
-    }
-
     /// create default configuration and save to file
     pub fn create_default() -> Result<Self, TapeConfigError> {
         let config = Self::default();
@@ -405,18 +214,6 @@ impl Default for TapeConfig {
                 max_poa_threads: 4,
                 max_pow_threads: 4
             },
-            performance: PerformanceConfig{
-                num_cores: num_cpus::get(),
-                max_memory_mb: 16384,
-                max_poa_threads: 4,
-                max_pow_threads: 4
-            },
-            performance: PerformanceConfig{
-                num_cores: num_cpus::get(),
-                max_memory_mb: 16384,
-                max_poa_threads: 4,
-                max_pow_threads: 4
-            },
             identity: IdentityConfig {
                 keypair_path: "~/.config/solana/id.json".to_string(),
             },
@@ -426,30 +223,6 @@ impl Default for TapeConfig {
                 commitment: CommitmentLevel::Confirmed,
                 priority_fee_lamports: 1000,
                 max_transaction_retries: 3,
-            },
-            storage: StorageConfig {
-                backend: StorageBackend::RocksDb,
-                rocksdb: Some(RocksDbConfig{
-                primary_path: "./db_tapestore".to_string(),
-                secondary_path: Some("./db_tapestore_secondary".to_string()),
-                cache_size_mb: 512,
-                })
-            },
-            logging: LoggingConfig {
-                log_level: LogLevel::Info,
-                log_path: Some("./logs/tape.log".to_string()),
-            },
-            storage: StorageConfig {
-                backend: StorageBackend::RocksDb,
-                rocksdb: Some(RocksDbConfig{
-                primary_path: "./db_tapestore".to_string(),
-                secondary_path: Some("./db_tapestore_secondary".to_string()),
-                cache_size_mb: 512,
-                })
-            },
-            logging: LoggingConfig {
-                log_level: LogLevel::Info,
-                log_path: Some("./logs/tape.log".to_string()),
             },
             storage: StorageConfig {
                 backend: StorageBackend::RocksDb,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -44,7 +44,8 @@ pub struct StorageConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RocksDbConfig {
     pub primary_path: String,
-    pub secondary_path: Option<String>,
+    pub secondary_path_mine: String,
+    pub secondary_path_web: String,
     pub cache_size_mb: u64,
 }
 
@@ -245,8 +246,9 @@ impl Default for TapeConfig {
             storage: StorageConfig {
                 backend: StorageBackend::RocksDb,
                 rocksdb: Some(RocksDbConfig{
-                primary_path: "./db_tapestore".to_string(),
-                secondary_path: Some("./db_tapestore_secondary".to_string()),
+                primary_path: "db_tapestore".to_string(),
+                secondary_path_mine: "db_tapestore_read_mine".to_string(),
+                secondary_path_web: "db_tapestore_read_web".to_string(),
                 cache_size_mb: 512,
                 })
             },

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -78,6 +78,18 @@ pub enum CommitmentLevel {
     Finalized,
 }
 
+impl SolanaConfig {
+    pub fn keypair_path(&self) -> PathBuf {
+        if self.keypair_path.is_empty() {
+            dirs::home_dir()
+                .expect("Could not find home directory")
+                .join(".config/solana/id.json")
+        } else {
+            PathBuf::from(&*shellexpand::tilde(&self.keypair_path))
+        }
+    }
+}
+
 impl ToString for CommitmentLevel {
     fn to_string(&self) -> String {
         match self {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -16,6 +16,7 @@ pub struct TapeConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MiningConfig {
+    pub miner_name: String,
     pub num_cores: usize,
     pub max_memory_mb: u64,
     pub max_poa_threads: u64,
@@ -209,6 +210,7 @@ impl Default for TapeConfig {
     fn default() -> Self {
         Self {
             mining: MiningConfig{
+                miner_name: "tape_miner".to_string(),
                 num_cores: num_cpus::get(),
                 max_memory_mb: 16384,
                 max_poa_threads: 4,
@@ -248,18 +250,7 @@ mod tests {
     fn test_toml_parsing_works_properly() {
         let toml_content = r#"
 [mining]
-num_cores = 4                    
-max_memory_mb = 16384            
-max_poa_threads = 4
-max_pow_threads = 4
-
-[performance]
-num_cores = 4                    
-max_memory_mb = 16384            
-max_poa_threads = 4
-max_pow_threads = 4
-
-[performance]
+miner_name = "tape_miner"
 num_cores = 4                    
 max_memory_mb = 16384            
 max_poa_threads = 4

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use solana_sdk::commitment_config::CommitmentConfig;
 use std::fmt;
+use crate::log::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TapeConfig {
@@ -117,7 +118,16 @@ impl TapeConfig {
             },
             None => {
                 let default_path = get_default_config_path()?;
-                Self::load_from_path(default_path)
+                match Self::load_from_path(&default_path) {
+                    Ok(config) => Ok(config),
+                    Err(TapeConfigError::ConfigFileNotFound) => {
+                        print_info("tape.toml not found, creating default configuration...");
+                        let config = Self::create_default()?;
+                        print_info("✓ Default configuration created successfully");
+                        Ok(config)
+                    },
+                    Err(e) => Err(e),
+                }
             }
         }
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TapeConfig {
-    pub mining_config: MiningConfig,
+    pub mining: MiningConfig,
     pub identity: IdentityConfig,
     pub solana: SolanaConfig,
     pub storage: StorageConfig,
@@ -103,7 +103,7 @@ impl CommitmentLevel {
 
 impl TapeConfig {
 
-   pub fn load_with_path(config_path: &Option<PathBuf>) -> Result<Self, TapeConfigError> {
+   pub fn load(config_path: &Option<PathBuf>) -> Result<Self, TapeConfigError> {
         match config_path {
             Some(path) => {
                 let expanded_path = expand_path(path);
@@ -208,7 +208,7 @@ pub fn get_default_config_path() -> Result<PathBuf, TapeConfigError> {
 impl Default for TapeConfig {
     fn default() -> Self {
         Self {
-            mining_config: MiningConfig{
+            mining: MiningConfig{
                 num_cores: num_cpus::get(),
                 max_memory_mb: 16384,
                 max_poa_threads: 4,
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_toml_parsing_works_properly() {
         let toml_content = r#"
-[mining_config]
+[mining]
 num_cores = 4                    
 max_memory_mb = 16384            
 max_poa_threads = 4

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -117,9 +117,9 @@ impl TapeConfig {
                 match Self::load_from_path(&default_path) {
                     Ok(config) => Ok(config),
                     Err(TapeConfigError::ConfigFileNotFound) => {
-                        print_info("tape.toml not found, creating default configuration...");
+                        print_info("No configuration found, creating default tape.toml...");
                         let config = Self::create_default()?;
-                        print_info("✓ Default configuration created successfully");
+                        print_info(&format!("✓ Created default configuration at {:?}", default_path));
                         Ok(config)
                     },
                     Err(e) => Err(e),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -8,7 +8,6 @@ use crate::log::*;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TapeConfig {
     pub mining: MiningConfig,
-    pub identity: IdentityConfig,
     pub solana: SolanaConfig,
     pub storage: StorageConfig,
     pub logging: LoggingConfig,
@@ -24,13 +23,10 @@ pub struct MiningConfig {
     pub max_pow_threads: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct IdentityConfig {
-    pub keypair_path: String,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SolanaConfig {
+    pub keypair_path: String,
     pub rpc_url: String,
     pub ws_url: Option<String>,
     pub commitment: CommitmentLevel,
@@ -155,7 +151,7 @@ impl TapeConfig {
         }
 
         // keypair validation
-        let keypair_path = &*shellexpand::tilde(&self.identity.keypair_path);
+        let keypair_path = &*shellexpand::tilde(&self.solana.keypair_path);
         if !Path::new(&keypair_path).exists() {
             return Err(TapeConfigError::KeypairNotFound(keypair_path.to_string()));
         }
@@ -226,10 +222,8 @@ impl Default for TapeConfig {
                 max_poa_threads: 4,
                 max_pow_threads: 4
             },
-            identity: IdentityConfig {
-                keypair_path: "~/.config/solana/id.json".to_string(),
-            },
             solana: SolanaConfig {
+                keypair_path: "~/.config/solana/id.json".to_string(),
                 rpc_url: "https://api.devnet.solana.com".to_string(),
                 ws_url: Some("wss://api.devnet.solana.com/".to_string()),
                 commitment: CommitmentLevel::Confirmed,
@@ -266,10 +260,8 @@ max_memory_mb = 16384
 max_poa_threads = 4
 max_pow_threads = 4
 
-[identity]
-keypair_path = "~/.config/solana/id.json"
-
 [solana]
+keypair_path = "~/.config/solana/id.json"
 rpc_url = "https://api.mainnet-beta.solana.com"
 ws_url = "wss://api.mainnet-beta.solana.com/"
 commitment = "finalized"
@@ -292,7 +284,7 @@ log_path = "./test.log"
         let config: TapeConfig = toml::from_str(toml_content).unwrap();
 
         
-        assert_eq!(config.identity.keypair_path, "~/.config/solana/id.json");
+        assert_eq!(config.solana.keypair_path, "~/.config/solana/id.json");
         assert_eq!(config.solana.rpc_url, "https://api.mainnet-beta.solana.com");
         assert_eq!(config.solana.ws_url, Some("wss://api.mainnet-beta.solana.com/".to_string()));
         assert_eq!(config.solana.commitment, CommitmentLevel::Finalized);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,447 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use solana_sdk::commitment_config::CommitmentConfig;
+use std::fmt;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TapeConfig {
+    pub mining_config: MiningConfig,
+    pub identity: IdentityConfig,
+    pub solana: SolanaConfig,
+    pub storage: StorageConfig,
+    pub logging: LoggingConfig,
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MiningConfig {
+    pub num_cores: usize,
+    pub max_memory_mb: u64,
+    pub max_poa_threads: u64,
+    pub max_pow_threads: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PerformanceConfig {
+    pub num_cores: usize,
+    pub max_memory_mb: u64,
+    pub max_poa_threads: u64,
+    pub max_pow_threads: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IdentityConfig {
+    pub keypair_path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SolanaConfig {
+    pub rpc_url: String,
+    pub ws_url: Option<String>,
+    pub commitment: CommitmentLevel,
+    pub priority_fee_lamports: u64,
+    pub max_transaction_retries: u32,
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StorageConfig {
+    pub backend: StorageBackend,
+    pub rocksdb: Option<RocksDbConfig>, 
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RocksDbConfig {
+    pub primary_path: String,
+    pub secondary_path: Option<String>,
+    pub cache_size_mb: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum StorageBackend {
+    RocksDb,
+    Postgres
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LoggingConfig {
+    pub log_level: LogLevel,
+    pub log_path: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CommitmentLevel {
+    Processed,
+    Confirmed, 
+    Finalized,
+}
+
+impl ToString for CommitmentLevel {
+    fn to_string(&self) -> String {
+        match self {
+            CommitmentLevel::Processed => "processed".to_string(),
+            CommitmentLevel::Confirmed => "confirmed".to_string(),
+            CommitmentLevel::Finalized => "finalized".to_string(),
+        }
+    }
+}
+
+impl CommitmentLevel {
+    pub fn to_commitment_config(&self) -> CommitmentConfig {
+        match self {
+            CommitmentLevel::Processed => CommitmentConfig::processed(),
+            CommitmentLevel::Confirmed => CommitmentConfig::confirmed(),
+            CommitmentLevel::Finalized => CommitmentConfig::finalized(),
+        }
+    }
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StorageConfig {
+    pub backend: StorageBackend,
+    pub rocksdb: Option<RocksDbConfig>, 
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RocksDbConfig {
+    pub primary_path: String,
+    pub secondary_path: Option<String>,
+    pub cache_size_mb: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum StorageBackend {
+    RocksDb,
+    Postgres
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LoggingConfig {
+    pub log_level: LogLevel,
+    pub log_path: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CommitmentLevel {
+    Processed,
+    Confirmed, 
+    Finalized,
+}
+
+impl ToString for CommitmentLevel {
+    fn to_string(&self) -> String {
+        match self {
+            CommitmentLevel::Processed => "processed".to_string(),
+            CommitmentLevel::Confirmed => "confirmed".to_string(),
+            CommitmentLevel::Finalized => "finalized".to_string(),
+        }
+    }
+}
+
+impl CommitmentLevel {
+    pub fn to_commitment_config(&self) -> CommitmentConfig {
+        match self {
+            CommitmentLevel::Processed => CommitmentConfig::processed(),
+            CommitmentLevel::Confirmed => CommitmentConfig::confirmed(),
+            CommitmentLevel::Finalized => CommitmentConfig::finalized(),
+        }
+    }
+}
+
+impl TapeConfig {
+
+   pub fn load_with_path(config_path: &Option<PathBuf>) -> Result<Self, TapeConfigError> {
+        match config_path {
+            Some(path) => {
+                let expanded_path = expand_path(path);
+                if !expanded_path.exists() {
+                    return Err(TapeConfigError::CustomConfigFileNotFound(
+                        expanded_path.display().to_string()
+                    ));
+                }
+                Self::load_from_path(expanded_path)
+            },
+            None => {
+                let default_path = get_default_config_path()?;
+                Self::load_from_path(default_path)
+            }
+        }
+    }
+
+    pub fn load_from_path<P: AsRef<Path>>(path: P) -> Result<Self, TapeConfigError> {
+        let path = path.as_ref();
+        
+        if !path.exists() {
+            return Err(TapeConfigError::ConfigFileNotFound);
+        }
+        
+        let contents = fs::read_to_string(path)
+            .map_err(TapeConfigError::FileReadError)?;
+        let config: TapeConfig = toml::from_str(&contents)
+            .map_err(TapeConfigError::ParseError)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), TapeConfigError> {
+        // solana rpc and websocket url validation
+        self.validate_url(&self.solana.rpc_url, "Solana RPC URL", &["http://", "https://"])?;
+        if let Some(ref ws_url) = self.solana.ws_url {
+            self.validate_url(ws_url, "Solana WebSocket URL", &["ws://", "wss://"])?;
+        }
+
+        // keypair validation
+        let keypair_path = &*shellexpand::tilde(&self.identity.keypair_path);
+        if !Path::new(&keypair_path).exists() {
+            return Err(TapeConfigError::KeypairNotFound(keypair_path.to_string()));
+        }
+
+        Ok(())
+    }
+
+    fn validate_url(&self, url: &str, field_name: &str, valid_schemes: &[&str]) -> Result<(), TapeConfigError> {
+        let has_valid_scheme = valid_schemes.iter().any(|scheme| url.starts_with(scheme));
+        
+        if !has_valid_scheme {
+            return Err(TapeConfigError::InvalidUrl(
+                format!("{} must start with one of {:?}, found: '{}'", field_name, valid_schemes, url)
+            ));
+        }
+
+        if url.contains(' ') {
+            return Err(TapeConfigError::InvalidUrl(
+                format!("{} cannot contain spaces, found: '{}'", field_name, url)
+            ));
+        }
+
+        if url.trim().is_empty() {
+            return Err(TapeConfigError::InvalidUrl(
+                format!("{} cannot be empty", field_name)
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_url(&self, url: &str, field_name: &str, valid_schemes: &[&str]) -> Result<(), TapeConfigError> {
+        let has_valid_scheme = valid_schemes.iter().any(|scheme| url.starts_with(scheme));
+        
+        if !has_valid_scheme {
+            return Err(TapeConfigError::InvalidUrl(
+                format!("{} must start with one of {:?}, found: '{}'", field_name, valid_schemes, url)
+            ));
+        }
+
+        if url.contains(' ') {
+            return Err(TapeConfigError::InvalidUrl(
+                format!("{} cannot contain spaces, found: '{}'", field_name, url)
+            ));
+        }
+
+        if url.trim().is_empty() {
+            return Err(TapeConfigError::InvalidUrl(
+                format!("{} cannot be empty", field_name)
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// create default configuration and save to file
+    pub fn create_default() -> Result<Self, TapeConfigError> {
+        let config = Self::default();
+        let toml_string = toml::to_string_pretty(&config)
+            .map_err(|e| TapeConfigError::DefaultConfigCreationFailed(format!("Serialization failed: {}", e)))?;
+            
+        let home_dir = dirs::home_dir()
+            .ok_or(TapeConfigError::HomeDirectoryNotFound)?;
+        let config_path = home_dir.join("tape.devnet.toml");
+        
+        fs::write(config_path, toml_string)
+            .map_err(|e| TapeConfigError::DefaultConfigCreationFailed(format!("Write failed: {}", e)))?;
+            
+        Ok(config)
+    }
+}
+
+pub fn get_default_config_path() -> Result<PathBuf, TapeConfigError> {
+    let home_dir = dirs::home_dir()
+        .ok_or(TapeConfigError::HomeDirectoryNotFound)?;
+    Ok(home_dir.join("tape.devnet.toml"))
+}
+
+    pub fn expand_path<P: AsRef<Path>>(path: P) -> PathBuf {
+        let path_str = path.as_ref().to_string_lossy();
+        let expanded = shellexpand::tilde(&path_str);
+        PathBuf::from(expanded.as_ref())
+    }
+
+impl Default for TapeConfig {
+    fn default() -> Self {
+        Self {
+            mining_config: MiningConfig{
+                num_cores: num_cpus::get(),
+                max_memory_mb: 16384,
+                max_poa_threads: 4,
+                max_pow_threads: 4
+            },
+            performance: PerformanceConfig{
+                num_cores: num_cpus::get(),
+                max_memory_mb: 16384,
+                max_poa_threads: 4,
+                max_pow_threads: 4
+            },
+            identity: IdentityConfig {
+                keypair_path: "~/.config/solana/id.json".to_string(),
+            },
+            solana: SolanaConfig {
+                rpc_url: "https://api.devnet.solana.com".to_string(),
+                ws_url: Some("wss://api.devnet.solana.com/".to_string()),
+                commitment: CommitmentLevel::Confirmed,
+                priority_fee_lamports: 1000,
+                max_transaction_retries: 3,
+            },
+            storage: StorageConfig {
+                backend: StorageBackend::RocksDb,
+                rocksdb: Some(RocksDbConfig{
+                primary_path: "./db_tapestore".to_string(),
+                secondary_path: Some("./db_tapestore_secondary".to_string()),
+                cache_size_mb: 512,
+                })
+            },
+            logging: LoggingConfig {
+                log_level: LogLevel::Info,
+                log_path: Some("./logs/tape.log".to_string()),
+            },
+            storage: StorageConfig {
+                backend: StorageBackend::RocksDb,
+                rocksdb: Some(RocksDbConfig{
+                primary_path: "./db_tapestore".to_string(),
+                secondary_path: Some("./db_tapestore_secondary".to_string()),
+                cache_size_mb: 512,
+                })
+            },
+            logging: LoggingConfig {
+                log_level: LogLevel::Info,
+                log_path: Some("./logs/tape.log".to_string()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toml_parsing_works_properly() {
+        let toml_content = r#"
+[mining_config]
+num_cores = 4                    
+max_memory_mb = 16384            
+max_poa_threads = 4
+max_pow_threads = 4
+
+[performance]
+num_cores = 4                    
+max_memory_mb = 16384            
+max_poa_threads = 4
+max_pow_threads = 4
+
+[identity]
+keypair_path = "~/.config/solana/id.json"
+
+[solana]
+rpc_url = "https://api.mainnet-beta.solana.com"
+ws_url = "wss://api.mainnet-beta.solana.com/"
+commitment = "finalized"
+priority_fee_lamports = 2000
+max_transaction_retries = 5
+
+[storage]
+backend = "rocksdb"
+
+[storage.rocksdb]
+primary_path = "./data/primary"
+secondary_path = "./data/secondary"
+cache_size_mb = 512
+
+[logging]
+log_level = "debug"
+log_path = "./test.log"
+"#;
+
+        let config: TapeConfig = toml::from_str(toml_content).unwrap();
+
+        
+        assert_eq!(config.identity.keypair_path, "~/.config/solana/id.json");
+        assert_eq!(config.solana.rpc_url, "https://api.mainnet-beta.solana.com");
+        assert_eq!(config.solana.ws_url, Some("wss://api.mainnet-beta.solana.com/".to_string()));
+        assert_eq!(config.solana.commitment, CommitmentLevel::Finalized);
+        assert_eq!(config.solana.priority_fee_lamports, 2000);
+        assert_eq!(config.solana.max_transaction_retries, 5);
+
+        assert_eq!(config.storage.backend, StorageBackend::RocksDb);  
+        let rocksdb_config = config.storage.rocksdb.as_ref().unwrap();
+        assert_eq!(rocksdb_config.primary_path, "./data/primary");
+        assert_eq!(rocksdb_config.secondary_path, Some("./data/secondary".to_string()));
+        assert_eq!(rocksdb_config.cache_size_mb, 512);
+
+
+        assert_eq!(config.logging.log_level, LogLevel::Debug);  
+        assert_eq!(config.logging.log_path, Some("./test.log".to_string()));
+    }
+}
+
+#[derive(Debug)]
+pub enum TapeConfigError {
+    ConfigFileNotFound,
+    CustomConfigFileNotFound(String),
+    InvalidUrl(String), 
+    KeypairNotFound(String), 
+    HomeDirectoryNotFound,
+    FileReadError(std::io::Error),
+    ParseError(toml::de::Error),
+    DefaultConfigCreationFailed(String),
+}
+
+impl fmt::Display for TapeConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TapeConfigError::ConfigFileNotFound => write!(f, "Configuration file not found"),
+            TapeConfigError::CustomConfigFileNotFound(path) => write!(f, "Configuration file not found at path: {}", path),
+            TapeConfigError::InvalidUrl(msg) => write!(f, "Invalid URL configuration: {}", msg),
+            TapeConfigError::KeypairNotFound(path) => write!(f, "Keypair not found at path: {}", path),
+            TapeConfigError::HomeDirectoryNotFound => write!(f, "Home directory not found"),
+            TapeConfigError::FileReadError(e) => write!(f, "Failed to read config file: {}", e),
+            TapeConfigError::ParseError(e) => write!(f, "Failed to parse config file: {}", e),
+            TapeConfigError::DefaultConfigCreationFailed(msg) => write!(f, "Failed to create default config: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for TapeConfigError {}

--- a/cli/src/keypair.rs
+++ b/cli/src/keypair.rs
@@ -22,17 +22,6 @@ pub fn load_keypair(path: &PathBuf) -> Result<Keypair> {
         .map_err(|e| anyhow!("Failed to create keypair from bytes: {}", e))
 }
 
-/// Loads the keypair from a specified path or the default Solana keypair location.
-pub fn get_keypair_path(keypair_path: &str) -> PathBuf {
-    if keypair_path.is_empty() {
-        dirs::home_dir()
-            .expect("Could not find home directory")
-            .join(".config/solana/id.json")
-    } else {
-        PathBuf::from(&*shellexpand::tilde(keypair_path))
-    }
-}
-
 pub fn get_payer(keypair_path: PathBuf) -> Result<Keypair> {
     let payer = match load_keypair(&keypair_path) {
         Ok(payer) => payer,

--- a/cli/src/keypair.rs
+++ b/cli/src/keypair.rs
@@ -23,12 +23,14 @@ pub fn load_keypair(path: &PathBuf) -> Result<Keypair> {
 }
 
 /// Loads the keypair from a specified path or the default Solana keypair location.
-pub fn get_keypair_path(keypair_path: Option<PathBuf>) -> PathBuf {
-    keypair_path.unwrap_or_else(|| {
+pub fn get_keypair_path(keypair_path: &str) -> PathBuf {
+    if keypair_path.is_empty() {
         dirs::home_dir()
             .expect("Could not find home directory")
             .join(".config/solana/id.json")
-    })
+    } else {
+        PathBuf::from(&*shellexpand::tilde(keypair_path))
+    }
 }
 
 pub fn get_payer(keypair_path: PathBuf) -> Result<Keypair> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,9 +3,10 @@ mod keypair;
 mod log;
 mod commands;
 mod utils;
+mod config;
 
 
-use anyhow::{Ok, Result};
+use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, Commands};
 use commands::{admin, read, write, info, snapshot, network, claim};
@@ -13,6 +14,7 @@ use env_logger::{self, Env};
 use tape_network::store::TapeStore;
 
 use crate::cli::Context;
+use crate::config::{TapeConfig, TapeConfigError};
 
 
 fn main() -> Result<()>{
@@ -37,9 +39,67 @@ async fn run_tape_cli() -> Result<()> {
     log::print_title(format!("⊙⊙ TAPEDRIVE {}", env!("CARGO_PKG_VERSION")).as_str());
 
     let cli = Cli::parse();
-  
 
-    let context = Context::try_build(&cli)?;
+    let config = match TapeConfig::load_with_path(&cli.config_path) {
+        Ok(config) => config,
+        Err(e) => match e {
+            TapeConfigError::ConfigFileNotFound => {
+                log::print_info("tape.toml not found, creating default configuration...");
+                match TapeConfig::create_default() {
+                    Ok(config) => {
+                        log::print_info("✓ Default configuration created successfully");
+                        config
+                    },
+                    Err(creation_error) => {
+                        log::print_error(&format!("{}", creation_error));
+                        std::process::exit(1);
+                    }
+                }
+            },
+
+            TapeConfigError::CustomConfigFileNotFound(path) => {
+            // This happens when user explicitly provided a path that doesn't exist
+            log::print_error(&format!("Custom config file not found: {}", path));
+            log::print_info("Please check the path and try again.");
+            std::process::exit(1);
+        },
+            
+            TapeConfigError::InvalidUrl(msg) => {
+                log::print_error(&format!("URL Configuration Error: {}", msg));
+                log::print_info("Please fix the URL in your tape.toml file and try again.");
+                std::process::exit(1);
+            },
+            
+            TapeConfigError::KeypairNotFound(path) => {
+                log::print_error(&format!("Keypair not found at path: {}", path));
+                log::print_info("Please ensure the keypair file exists at the specified path in tape.toml");
+                std::process::exit(1);
+            },
+            
+            TapeConfigError::FileReadError(io_err) => {
+                log::print_error(&format!("Could not read config file: {}", io_err));
+                std::process::exit(1);
+            },
+            
+            TapeConfigError::ParseError(parse_err) => {
+                log::print_error(&format!("Invalid tape.toml format: {}", parse_err));
+                log::print_info("Please check your tape.toml file syntax.");
+                std::process::exit(1);
+            },
+            
+            TapeConfigError::HomeDirectoryNotFound => {
+                log::print_error("Could not determine home directory");
+                std::process::exit(1);
+            },
+            
+            TapeConfigError::DefaultConfigCreationFailed(msg) => {
+                log::print_error(&format!("Failed to create default config: {}", msg));
+                std::process::exit(1);
+            },
+        }
+    };
+
+    let context = Context::try_build(&cli, &config)?;
 
     match cli.command {
         Commands::Init {} |

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,7 +87,9 @@ async fn run_tape_cli() -> Result<()> {
         Commands::Web { .. } |
         Commands::Archive { .. } |
         Commands::Mine { .. } => {
-            TapeStore::try_init_store()?;
+            let rocksdb_config = context.config.storage.rocksdb.as_ref()
+              .ok_or_else(|| anyhow::anyhow!("RocksDB config not found"))?;
+            TapeStore::try_init_store(&rocksdb_config.primary_path)?;
             network::handle_network_commands(cli, context).await?;
         }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,7 +14,6 @@ use env_logger::{self, Env};
 use tape_network::store::TapeStore;
 
 use crate::cli::Context;
-use crate::config::{TapeConfig, TapeConfigError};
 
 
 fn main() -> Result<()>{
@@ -40,66 +39,7 @@ async fn run_tape_cli() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let config = match TapeConfig::load(&cli.config) {
-        Ok(config) => config,
-        Err(e) => match e {
-            TapeConfigError::ConfigFileNotFound => {
-                log::print_info("tape.toml not found, creating default configuration...");
-                match TapeConfig::create_default() {
-                    Ok(config) => {
-                        log::print_info("✓ Default configuration created successfully");
-                        config
-                    },
-                    Err(creation_error) => {
-                        log::print_error(&format!("{}", creation_error));
-                        std::process::exit(1);
-                    }
-                }
-            },
-
-            TapeConfigError::CustomConfigFileNotFound(path) => {
-            // This happens when user explicitly provided a path that doesn't exist
-            log::print_error(&format!("Custom config file not found: {}", path));
-            log::print_info("Please check the path and try again.");
-            std::process::exit(1);
-        },
-            
-            TapeConfigError::InvalidUrl(msg) => {
-                log::print_error(&format!("URL Configuration Error: {}", msg));
-                log::print_info("Please fix the URL in your tape.toml file and try again.");
-                std::process::exit(1);
-            },
-            
-            TapeConfigError::KeypairNotFound(path) => {
-                log::print_error(&format!("Keypair not found at path: {}", path));
-                log::print_info("Please ensure the keypair file exists at the specified path in tape.toml");
-                std::process::exit(1);
-            },
-            
-            TapeConfigError::FileReadError(io_err) => {
-                log::print_error(&format!("Could not read config file: {}", io_err));
-                std::process::exit(1);
-            },
-            
-            TapeConfigError::ParseError(parse_err) => {
-                log::print_error(&format!("Invalid tape.toml format: {}", parse_err));
-                log::print_info("Please check your tape.toml file syntax.");
-                std::process::exit(1);
-            },
-            
-            TapeConfigError::HomeDirectoryNotFound => {
-                log::print_error("Could not determine home directory");
-                std::process::exit(1);
-            },
-            
-            TapeConfigError::DefaultConfigCreationFailed(msg) => {
-                log::print_error(&format!("Failed to create default config: {}", msg));
-                std::process::exit(1);
-            },
-        }
-    };
-
-    let context = Context::try_build(&cli, &config)?;
+    let context = Context::try_build(&cli)?;
 
     match cli.command {
         Commands::Init {} |

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,7 +40,7 @@ async fn run_tape_cli() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let config = match TapeConfig::load_with_path(&cli.config_path) {
+    let config = match TapeConfig::load(&cli.config) {
         Ok(config) => config,
         Err(e) => match e {
             TapeConfigError::ConfigFileNotFound => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,8 +49,7 @@ async fn run_tape_cli() -> Result<()> {
         => {
             log::print_message(&format!(
                 "Using keypair from {}",
-                context.keyapir_path().display()
-                
+                context.keypair_path().display()
             ));
         }
         _ => {}

--- a/client/src/tape/write.rs
+++ b/client/src/tape/write.rs
@@ -7,10 +7,7 @@ use solana_sdk::{
 };
 use tape_api::instruction::tape::build_write_ix;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use crate::{
-    consts::*,
-    utils::*,
-};
+use crate::utils::*;
 
 pub async fn write_to_tape(
     client: &Arc<RpcClient>,
@@ -18,6 +15,7 @@ pub async fn write_to_tape(
     tape_address: Pubkey,
     writer_address: Pubkey,
     data: &[u8],
+    max_transaction_retries: u32
 ) -> Result<Signature> {
 
     let instruction = build_write_ix(
@@ -27,7 +25,6 @@ pub async fn write_to_tape(
         data,
     );
 
-    let sig = send_with_retry(client, &instruction, signer, MAX_RETRIES).await?;
+    let sig = send_with_retry(client, &instruction, signer, max_transaction_retries).await?;
     Ok(sig)
 }
-

--- a/network/src/store/helpers.rs
+++ b/network/src/store/helpers.rs
@@ -1,4 +1,4 @@
-use super::{TapeStore, StoreError, consts::*};
+use super::{TapeStore, StoreError};
 use std::{env, sync::Arc};
 
 pub fn primary(tape_store_primary_db: &str) -> Result<TapeStore, StoreError> {
@@ -24,9 +24,9 @@ pub fn secondary_web(tape_store_primary_db: &str, tape_store_secondary_db_web: &
     TapeStore::new_secondary(&db_primary, &db_secondary)
 }
 
-pub fn read_only() -> Result<TapeStore, StoreError> {
+pub fn read_only(tape_store_primary_db: &str,) -> Result<TapeStore, StoreError> {
     let current_dir = env::current_dir().map_err(StoreError::IoError)?;
-    let db_primary = current_dir.join(TAPE_STORE_PRIMARY_DB);
+    let db_primary = current_dir.join(tape_store_primary_db);
     TapeStore::new_read_only(&db_primary)
 }
 

--- a/network/src/store/helpers.rs
+++ b/network/src/store/helpers.rs
@@ -1,9 +1,9 @@
 use super::{TapeStore, StoreError, consts::*};
 use std::{env, sync::Arc};
 
-pub fn primary() -> Result<TapeStore, StoreError> {
+pub fn primary(tape_store_primary_db: &str) -> Result<TapeStore, StoreError> {
     let current_dir = env::current_dir().map_err(StoreError::IoError)?;
-    let db_primary = current_dir.join(TAPE_STORE_PRIMARY_DB);
+    let db_primary = current_dir.join(tape_store_primary_db);
     std::fs::create_dir_all(&db_primary).map_err(StoreError::IoError)?;
     TapeStore::new(&db_primary)
 }

--- a/network/src/store/helpers.rs
+++ b/network/src/store/helpers.rs
@@ -8,10 +8,10 @@ pub fn primary() -> Result<TapeStore, StoreError> {
     TapeStore::new(&db_primary)
 }
 
-pub fn secondary_mine() -> Result<TapeStore, StoreError> {
+pub fn secondary_mine(tape_store_primary_db: &str, tape_store_secondary_db_mine: &str) -> Result<TapeStore, StoreError> {
     let current_dir = env::current_dir().map_err(StoreError::IoError)?;
-    let db_primary = current_dir.join(TAPE_STORE_PRIMARY_DB);
-    let db_secondary = current_dir.join(TAPE_STORE_SECONDARY_DB_MINE);
+    let db_primary = current_dir.join(tape_store_primary_db);
+    let db_secondary = current_dir.join(tape_store_secondary_db_mine);
     std::fs::create_dir_all(&db_secondary).map_err(StoreError::IoError)?;
     TapeStore::new_secondary(&db_primary, &db_secondary)
 }

--- a/network/src/store/helpers.rs
+++ b/network/src/store/helpers.rs
@@ -16,10 +16,10 @@ pub fn secondary_mine(tape_store_primary_db: &str, tape_store_secondary_db_mine:
     TapeStore::new_secondary(&db_primary, &db_secondary)
 }
 
-pub fn secondary_web() -> Result<TapeStore, StoreError> {
+pub fn secondary_web(tape_store_primary_db: &str, tape_store_secondary_db_web: &str) -> Result<TapeStore, StoreError> {
     let current_dir = env::current_dir().map_err(StoreError::IoError)?;
-    let db_primary = current_dir.join(TAPE_STORE_PRIMARY_DB);
-    let db_secondary = current_dir.join(TAPE_STORE_SECONDARY_DB_WEB);
+    let db_primary = current_dir.join(tape_store_primary_db);
+    let db_secondary = current_dir.join(tape_store_secondary_db_web);
     std::fs::create_dir_all(&db_secondary).map_err(StoreError::IoError)?;
     TapeStore::new_secondary(&db_primary, &db_secondary)
 }

--- a/network/src/store/store.rs
+++ b/network/src/store/store.rs
@@ -25,8 +25,8 @@ impl TapeStore {
         Ok(Self { db })
     }
 
-    pub fn try_init_store() -> Result<(), StoreError> {
-        if let Ok(_store) = super::helpers::primary() {
+    pub fn try_init_store(tape_store_primary_db: &str) -> Result<(), StoreError> {
+        if let Ok(_store) = super::helpers::primary(tape_store_primary_db) {
             log::debug!("Primary store initialized successfully");
         }
         Ok(())
@@ -74,4 +74,3 @@ impl Drop for TapeStore {
         // RocksDB handles cleanup automatically
     }
 }
-

--- a/tape.example.toml
+++ b/tape.example.toml
@@ -1,4 +1,4 @@
-[mining_config]
+[mining]
 num_cores = 4                    
 max_memory_mb = 16384            
 max_poa_threads = 4

--- a/tape.example.toml
+++ b/tape.example.toml
@@ -4,10 +4,8 @@ max_memory_mb = 16384
 max_poa_threads = 4
 max_pow_threads = 4
 
-[identity]
-keypair_path = "~/.config/solana/id.json"
-
 [solana]
+keypair_path = "~/.config/solana/id.json"
 rpc_url = "https://api.mainnet-beta.solana.com"
 ws_url = "wss://api.mainnet-beta.solana.com/"
 commitment = "finalized"

--- a/tape.example.toml
+++ b/tape.example.toml
@@ -1,0 +1,27 @@
+[mining_config]
+num_cores = 4                    
+max_memory_mb = 16384            
+max_poa_threads = 4
+max_pow_threads = 4
+
+[identity]
+keypair_path = "~/.config/solana/id.json"
+
+[solana]
+rpc_url = "https://api.mainnet-beta.solana.com"
+ws_url = "wss://api.mainnet-beta.solana.com/"
+commitment = "finalized"
+priority_fee_lamports = 2000
+max_transaction_retries = 5
+
+[storage]
+backend = "rocksdb"
+
+[storage.rocksdb]
+primary_path = "./data/primary"
+secondary_path = "./data/secondary"
+cache_size_mb = 512
+
+[logging]
+log_level = "debug"
+log_path = "./test.log"


### PR DESCRIPTION
PR for #16 

I have pushed code of simple implementation of using `tape.toml` . In the following code change of only `rpc_url` is used from `tape.toml` config file. Couple of changes I made

- add `toml` crate for handling toml file
- removed default cluster option of `l` from cli args
- priority is given to cli commands. if cluster is mention in cli command, `rpc_url` from `tape.toml` wont be used. if not it will be used. 
- if config is loaded from `tape.toml` it is passed through cli context 
- `tape.toml` is created at home dir 

I tested the above change in `archive` command

`~/tape.toml`
```toml
[solana]
rpc_url = "https://api.devnet.solana.com"
ws_url = "wss://api.devnet.solana.com/"
commitment = "confirmed"
```

- `cargo run -p tapedrive-cli --manifest-path ~/Documents/solana/tape/cli/Cargo.toml archive`
   <img width="463" height="91" alt="Screenshot 2025-08-07 at 1 35 20 PM" src="https://github.com/user-attachments/assets/57811755-3dd7-4812-83b7-5bda15a2f1e4" />

- `cargo run -p tapedrive-cli --manifest-path ~/Documents/solana/tape/cli/Cargo.toml archive -ul`
   <img width="374" height="90" alt="Screenshot 2025-08-07 at 1 35 53 PM" src="https://github.com/user-attachments/assets/31c077a3-2327-4760-a6d9-e59bdcc95630" />
