### PR TITLE
Fix dynamic wait time for writes

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_sdk::signature::Keypair;
 use tape_network::store::TapeStore;
 use std::env;
@@ -26,9 +26,9 @@ pub struct Cli {
     pub keypair_path: Option<PathBuf>,
 
     #[arg(
-        short = 'u', 
-        long = "cluster", 
-        default_value = "l", 
+        short = 'u',
+        long = "cluster",
+        default_value = "l",
         global = true,
         help = "Cluster to use: l (localnet), m (mainnet), d (devnet), t (testnet),\n or a custom RPC URL"
     )]
@@ -36,6 +36,13 @@ pub struct Cli {
 
     #[arg(short = 'v', long = "verbose", help = "Print verbose output", global = true)]
     pub verbose: bool,
+
+    #[arg(
+        long = "commitment",
+        default_value = "finalized",
+        global = true,
+    )]
+    pub commitment: CommitmentLevel
 }
 
 #[derive(Subcommand)]
@@ -249,11 +256,11 @@ impl Context{
         let rpc_url = cli.cluster.rpc_url();
         let rpc = Arc::new(
             RpcClient::new_with_commitment(rpc_url.clone(),
-            CommitmentConfig::finalized())
+            CommitmentConfig { commitment: cli.commitment.clone() })
         );
         let keypair_path = get_keypair_path(cli.keypair_path.clone());
         let payer = get_payer(keypair_path.clone())?;
-        
+
         Ok(Self {
              rpc,
              keypair_path,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -44,7 +44,16 @@ pub struct Cli {
     )]
     pub commitment: CommitmentLevel
 }
+impl Cli {
+	pub fn commitment_time(&self)-> u64 {
+    match self.commitment {
+        CommitmentLevel::Confirmed => 32,
+        CommitmentLevel::Finalized => 16,
+        CommitmentLevel::Processed => 8,
+    }
+}
 
+}
 #[derive(Subcommand)]
 pub enum Commands {
 

--- a/cli/src/commands/write.rs
+++ b/cli/src/commands/write.rs
@@ -104,7 +104,7 @@ pub async fn handle_write_command(cli: Cli, context: Context) -> Result<()> {
         write_chunks(&rpc, &payer, tape_address, writer_address, chunks, &pb).await?;
 
         pb.set_message("finalizing tape...");
-        tokio::time::sleep(Duration::from_secs(32)).await;
+        tokio::time::sleep(Duration::from_secs(cli.commitment_time())).await;
 
         set_header(&rpc, &payer, tape_address, header).await?;
         subsidize_tape(&rpc, &payer, tape_address, payer_ata, required_rent).await?;
@@ -291,4 +291,3 @@ fn read_from_stdin() -> std::io::Result<Vec<u8>> {
     std::io::stdin().read_to_end(&mut buffer)?;
     Ok(buffer)
 }
-


### PR DESCRIPTION
Previously, the thread was set to wait for a fixed duration of 32 seconds, which is not ideal.
This change updates the behavior to wait dynamically based on the commitment level provided through the CLI.