### PR TITLE
Remove the 32-second delay using send_and_confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![image](https://github.com/user-attachments/assets/bf674eb1-512d-47e7-a9c5-e0d0e44c6edb)
 
 > [!Important]
-> Tapedrive is very much still in development, it is **not deployed** to mainnet yet.
+> Tapedrive is very much still in development, it is **not deployed** to mainnet yet. A [new version](https://x.com/zelimir__/status/1975304835064078660) is in the works.
 > 
 > [Sign up](https://tapedrive.io/#sign-up) to receive updates on network milestones and product releases. Join us on [Discord](https://discord.gg/dVa9TWA45X) to engage with our devs.
 

--- a/cli/src/commands/write.rs
+++ b/cli/src/commands/write.rs
@@ -104,7 +104,6 @@ pub async fn handle_write_command(cli: Cli, context: Context) -> Result<()> {
         write_chunks(&rpc, &payer, tape_address, writer_address, chunks, &pb).await?;
 
         pb.set_message("finalizing tape...");
-        tokio::time::sleep(Duration::from_secs(32)).await;
 
         set_header(&rpc, &payer, tape_address, header).await?;
         subsidize_tape(&rpc, &payer, tape_address, payer_ata, required_rent).await?;

--- a/client/src/utils/rpc.rs
+++ b/client/src/utils/rpc.rs
@@ -127,7 +127,7 @@ pub async fn send_with_retry(
             recent_blockhash,
         );
 
-        match send(client, &tx).await {
+        match send_and_confirm(client, &tx).await {
             Ok(signature) => return Ok(signature),
             Err(e) if attempts < max_retries => {
                 attempts += 1;


### PR DESCRIPTION
#38 Fix  Remove tokio sleep for 32 second
Now the function uses send_and_confirm to wait until the transaction is confirmed, making the process more reliable and faster.

https://github.com/spool-labs/tape/pull/40#issuecomment-3263534817 
Go with 1 Approch